### PR TITLE
Refactor/visit methods

### DIFF
--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -36,7 +36,11 @@ impl VisitMut for AddDisplayNameVisitor {
 
         self.components.iter().enumerate().for_each(|(i, comp)| {
             let index = i + comp.pos + 1;
-            stmts.insert(index, ModuleItem::Stmt(set_display_name_stmt(comp)));
+            if index < stmts.len() {
+                stmts.insert(index, ModuleItem::Stmt(set_display_name_stmt(comp)));
+            } else {
+                stmts.push(ModuleItem::Stmt(set_display_name_stmt(comp)));
+            }
         })
     }
 

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -35,8 +35,6 @@ impl VisitMut for AddDisplayNameVisitor {
         stmts.visit_mut_children_with(self);
 
         stmts.iter_mut().enumerate().for_each(|(i, stmt)| {
-            if let Some(comp) = export_var_decl(stmt) { self.components.push(comp.with_pos(i)) }
-            if let Some(comp) = var_decl_stmt(stmt) { self.components.push(comp.with_pos(i)) }
             if let Some(comp) = default_export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
             if let Some(comp) = export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
             if let Some(comp) = bare_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
@@ -47,21 +45,12 @@ impl VisitMut for AddDisplayNameVisitor {
             stmts.insert(index, ModuleItem::Stmt(set_display_name_stmt(comp)));
         })
     }
-}
 
-fn export_var_decl(stmt: &mut ModuleItem) -> Option<Component> {
-    let var_decls = stmt.as_mut_module_decl()?.as_mut_export_decl()?.decl.as_mut_var()?.as_mut();
-    process_var_decls(var_decls)
-}
-
-fn var_decl_stmt(stmt: &mut ModuleItem) -> Option<Component> {
-    let var_decls = stmt.as_mut_stmt()?.as_mut_decl()?.as_mut_var()?.as_mut();
-    process_var_decls(var_decls)
-}
-
-fn process_var_decls(var_decls: &mut VarDecl) -> Option<Component> {
-    if var_decls.decls.len() != 1 { return None };
-    process_var_declarator(&mut var_decls.decls[0])
+    fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
+        if let Some(comp) = process_var_declarator(n) {
+            self.components.push(comp.with_pos(self.components.len()))
+        }
+    }
 }
 
 fn process_var_declarator(var_decl: &mut VarDeclarator) -> Option<Component> {

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -35,7 +35,6 @@ impl VisitMut for AddDisplayNameVisitor {
         stmts.visit_mut_children_with(self);
 
         stmts.iter_mut().enumerate().for_each(|(i, stmt)| {
-            if let Some(comp) = default_export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
             if let Some(comp) = export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
             if let Some(comp) = bare_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
         });
@@ -48,6 +47,12 @@ impl VisitMut for AddDisplayNameVisitor {
 
     fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
         if let Some(comp) = process_var_declarator(n) {
+            self.components.push(comp.with_pos(self.components.len()))
+        }
+    }
+
+    fn visit_mut_fn_expr(&mut self, n: &mut FnExpr) {
+        if let Some(comp) = process_fn_expr(n) {
             self.components.push(comp.with_pos(self.components.len()))
         }
     }
@@ -67,11 +72,6 @@ fn process_var_declarator(var_decl: &mut VarDeclarator) -> Option<Component> {
         name: name.sym.clone(),
         ctx: name.span.ctxt
     })
-}
-
-fn default_export_fn_decl(stmt: &mut ModuleItem) -> Option<Component> {
-    let fn_expr = stmt.as_mut_module_decl()?.as_mut_export_default_decl()?.decl.as_mut_fn_expr()?;
-    process_fn_expr(fn_expr)
 }
 
 fn process_fn_expr(fn_expr: &mut FnExpr) -> Option<Component> {

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -18,22 +18,31 @@ impl Component {
     }
 }
 
-pub struct AddDisplayNameVisitor;
+pub struct AddDisplayNameVisitor {
+    components: Vec<Component>,
+}
+
+impl Default for AddDisplayNameVisitor {
+    fn default() -> AddDisplayNameVisitor {
+        AddDisplayNameVisitor {
+            components: Vec::new(),
+        }
+    }
+}
 
 impl VisitMut for AddDisplayNameVisitor {
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
         stmts.visit_mut_children_with(self);
 
-        let mut components: Vec<Component> = Vec::new();
         stmts.iter_mut().enumerate().for_each(|(i, stmt)| {
-            if let Some(comp) = export_var_decl(stmt) { components.push(comp.with_pos(i)) }
-            if let Some(comp) = var_decl_stmt(stmt) { components.push(comp.with_pos(i)) }
-            if let Some(comp) = default_export_fn_decl(stmt) { components.push(comp.with_pos(i)) }
-            if let Some(comp) = export_fn_decl(stmt) { components.push(comp.with_pos(i)) }
-            if let Some(comp) = bare_fn_decl(stmt) { components.push(comp.with_pos(i)) }
+            if let Some(comp) = export_var_decl(stmt) { self.components.push(comp.with_pos(i)) }
+            if let Some(comp) = var_decl_stmt(stmt) { self.components.push(comp.with_pos(i)) }
+            if let Some(comp) = default_export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
+            if let Some(comp) = export_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
+            if let Some(comp) = bare_fn_decl(stmt) { self.components.push(comp.with_pos(i)) }
         });
 
-        components.iter().enumerate().for_each(|(i, comp)| {
+        self.components.iter().enumerate().for_each(|(i, comp)| {
             let index = i + comp.pos + 1;
             stmts.insert(index, ModuleItem::Stmt(set_display_name_stmt(comp)));
         })

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -61,8 +61,10 @@ fn var_decl_stmt(stmt: &mut ModuleItem) -> Option<Component> {
 
 fn process_var_decls(var_decls: &mut VarDecl) -> Option<Component> {
     if var_decls.decls.len() != 1 { return None };
-    let var_decl = &mut var_decls.decls[0];
+    process_var_declarator(&mut var_decls.decls[0])
+}
 
+fn process_var_declarator(var_decl: &mut VarDeclarator) -> Option<Component> {
     if let Some(init) = &var_decl.init {
         if init.is_jsx_element() || init.is_jsx_fragment() || init.is_paren() { return None; }
     }

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -38,16 +38,9 @@ impl Component {
     }
 }
 
+#[derive(Default)]
 pub struct AddDisplayNameVisitor {
     components: Vec<Component>,
-}
-
-impl Default for AddDisplayNameVisitor {
-    fn default() -> AddDisplayNameVisitor {
-        AddDisplayNameVisitor {
-            components: Vec::new(),
-        }
-    }
 }
 
 impl VisitMut for AddDisplayNameVisitor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use swc_core::plugin::{plugin_transform, proxies::TransformPluginProgramMetadata
 
 #[plugin_transform]
 pub fn process_transform(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
-    program.fold_with(&mut as_folder(AddDisplayNameVisitor))
+    program.fold_with(&mut as_folder(AddDisplayNameVisitor::default()))
 }
 
 #[cfg(test)]
@@ -33,7 +33,7 @@ mod test {
     fn runner(_: &mut Tester) -> impl Fold {
         chain!(
             resolver(Mark::new(), Mark::new(), false),
-            as_folder(super::AddDisplayNameVisitor)
+            as_folder(super::AddDisplayNameVisitor::default())
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,18 @@ mod test {
     );
 
     test!(SYNTAX, runner,
+        /* Name */ one_const_statement_multiple_exprs,
+        /* Input */ r#"
+            const Foo = () => <div />, Bar = memo(() => <div />);
+        "#,
+        /* Output */ r#"
+            const Foo = () => <div />, Bar = memo(() => <div />);
+            Foo.displayName = "Foo";
+            Bar.displayName = "Bar";
+        "#
+    );
+
+    test!(SYNTAX, runner,
         /* Name */ should_not_work_on_normal_fn,
         /* Input */ r#"
             export const fn = () => console.log();


### PR DESCRIPTION
Hi @hjkcai , thanks for merging the previous PR and publish a new version. When I test that on my repo, it still panics with `RuntimeError: unreachable` or `RuntimeError: out of bounds memory access`. Unfortunately, the compiled wasm plugin was hard to debug and I'm trying my best here. I'm hoping the bast that `if index < stmts.len() {` should fix this issue.

I also did some refactoring to use the native `visit_` methods so that it seems more natural way to do.

![JPEG-1](https://github.com/hjkcai/swc-plugin-add-display-name/assets/922234/36f88be7-42f9-466c-8a32-f64283f7054c)
