### PR TITLE
Fix/access before initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_add_display_name"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "swc_core",

--- a/src/add_display_name.rs
+++ b/src/add_display_name.rs
@@ -40,12 +40,16 @@ impl Component {
 
 #[derive(Default)]
 pub struct AddDisplayNameVisitor {
+    pos: usize,
     components: Vec<Component>,
 }
 
 impl VisitMut for AddDisplayNameVisitor {
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
-        stmts.visit_mut_children_with(self);
+        stmts.iter_mut().enumerate().for_each(|(i, stmt)| {
+            self.pos = i;
+            stmt.visit_mut_children_with(self);
+        });
 
         self.components.iter().enumerate().for_each(|(i, comp)| {
             let index = i + comp.pos + 1;
@@ -59,19 +63,19 @@ impl VisitMut for AddDisplayNameVisitor {
 
     fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
         if let Some(comp) = process_var_declarator(n) {
-            self.components.push(comp.with_pos(self.components.len()))
+            self.components.push(comp.with_pos(self.pos))
         }
     }
 
     fn visit_mut_fn_expr(&mut self, n: &mut FnExpr) {
         if let Some(comp) = process_fn_expr(n) {
-            self.components.push(comp.with_pos(self.components.len()))
+            self.components.push(comp.with_pos(self.pos))
         }
     }
 
     fn visit_mut_fn_decl(&mut self, n: &mut FnDecl) {
         if let Some(comp) = process_fn_decl(n) {
-            self.components.push(comp.with_pos(self.components.len()))
+            self.components.push(comp.with_pos(self.pos))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,24 @@ mod test {
         "#
     );
 
+
+    test!(SYNTAX, runner,
+        /* Name */ fn_expression_export_multiline,
+        /* Input */ r#"
+            const a = {};
+            export const Component = function() {
+                return <div />; 
+            }
+            export default Component;
+        "#,
+        /* Output */ r#"
+            const a = {};
+            export const Component = function() { return <div />; }
+            Component.displayName = "Component";
+            export default Component;
+        "#
+    );
+
     test!(SYNTAX, runner,
         /* Name */ fn_declaration_export,
         /* Input */ r#"


### PR DESCRIPTION
I've found another bug in my previous PR #4 that causes the `.displayName` being set before variable intialization.

![JPEG-1](https://github.com/hjkcai/swc-plugin-add-display-name/assets/922234/4add92d4-9943-43e1-81dd-9d30619c0cad)
