### PR TITLE
fix: not rewrite and not duplicate existed displayNames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,4 +300,28 @@ mod test {
             });
         "#
     );
+
+    test_inline!(SYNTAX, runner,
+        /* Name */ should_not_duplicate_existed,
+        /* Input */ r#"
+            export const Component = function() { return <div />; }
+            Component.displayName = "Component";
+        "#,
+        /* Output */ r#"
+            export const Component = function() { return <div />; }
+            Component.displayName = "Component";
+        "#
+    );
+
+    test_inline!(SYNTAX, runner,
+        /* Name */ should_not_rewrite_existed,
+        /* Input */ r#"
+            export const Component = function() { return <div />; }
+            Component.displayName = "CustomName";
+        "#,
+        /* Output */ r#"
+            export const Component = function() { return <div />; }
+            Component.displayName = "CustomName";
+        "#
+    );
 }


### PR DESCRIPTION
This pull request fix cases when component already have assigned displayName. 
It helps to reduce bundle size

Before this pull request behaviour: 
```
// input:
export const Component = function() { return <div />; }
Component.displayName = "Component";

// output:
export const Component = function() { return <div />; }
Component.displayName = "Component";
Component.displayName = "Component";
```
